### PR TITLE
Globally-enforced coherence

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ class ClassName {
 }
 
 let instance = new ClassName();
-ProtocolName(instance).providedMethodName();
+instance[ProtocolName].providedMethodName();
 ```
 
 ## What is it used for?
@@ -41,7 +41,7 @@ protocol ToString {
   tag;
 
   toString() {
-    return `[object ${ToString(this).tag}]`;
+    return `[object ${this[ToString].tag}]`;
   }
 
   // Coherence-guaranteed implementation for existing classes
@@ -79,7 +79,7 @@ protocol Ordered {
   compare;
 
   lessThan(other) {
-    return Ordered(this).compare(other) === Ordered.LT;
+    return this[Ordered].compare(other) === Ordered.LT;
   }
 
   implFor String {
@@ -93,8 +93,8 @@ protocol Ordered {
   }
 }
 
-(2).compare(1) // Ordered.GT
-'a'.lessThan('aa') // true
+(2)[Ordered].compare(1) // Ordered.GT
+'a'[Ordered].lessThan('aa') // true
 ```
 
 ## Other Features
@@ -233,7 +233,7 @@ protocol Thenable {
 
   implFor Promise {
     // Forward the private Thenable then() method to the existing public
-    then () { return this.then.apply(this, arguments) }
+    then() { return this.then.apply(this, arguments) }
   }
 }
 
@@ -244,6 +244,7 @@ class MyOldDeferred {
   }
   implements Thenable {
     then(onResolve, onReject) {
+      // Call the toplevel, regular method.
       return this.then(onResolve, onReject)
     }
   }
@@ -251,7 +252,7 @@ class MyOldDeferred {
 
 // These both do the same thing.
 new MyOldDeferred().then(console.log)
-Thenable(new MyOldDeferred()).then(console.log)
+new MyOldDeferred()[Thenable].then(console.log)
 ```
 
 ### combined export form
@@ -266,16 +267,32 @@ export protocol I {
 }
 ```
 
+### `super`
+
+The `super` keyword inside a protocol implementation works as it usually would:
+
+```js
+protocol Proto { then; }
+
+class Parent {
+  implements Proto {
+    greet() { return 'hello'; }
+  }
+}
+
+class Child extends Parent {
+  implements Proto {
+    greet() { return super[Proto].greet() + ' world'; }
+  }
+}
+
+```
+
 ## Open questions or issues
 
 1. Should protocols inherit from Object.prototype?
 1. Should protocols be immutable prototype exotic objects? Frozen? Sealed?
-1. Do we want to have protocols inherit from some `Protocol.prototype` object so they can be abstracted over?
-1. Should implementing a protocol actually copy symbols to prototype/constructor or use internal slots for resolution?
-1. Is there a way we can make `super` properties and `super` calls work?
-1. How does this have to interact with the global symbol registry?
 1. Should methods be created in realm of implementor or just once in realm of definition?
-
 
 ## Relationship to similar features
 


### PR DESCRIPTION
I really like this proposal and I'm super into having something like this in the language! Thank you for the work you've done on this so far!

Some background behind this PR: Last time @michaelficarra and I talked about it, the topic of coherence came up, and we didn't have any good solutions for this at the time. After having more conversations about this with folks this past week and thinking more about the issue, I came up with this idea for enforcing coherence across the entire language and letting us have our cake and eat it, too.

This PR is still a WIP as I try and sketch out how we can have this coherence guarantee and provide some other guarantees that would be nice to have in something like this.This is, of course, an _initial_ sketch of the idea and I'm not even entirely sure this would work in all relevant cases, but I'd like to show what I mean if and when we start discussing how this feature might solve the coherence problem.

For those of us unfamiliar with what I'm referring to, you can read section on coherence in [Rust's documentation about defining traits](https://doc.rust-lang.org/book/second-edition/ch10-02-traits.html#defining-a-trait), as well as the [traits RFC itself](https://github.com/rust-lang/rfcs/blob/master/text/0048-traits.md).

The tl;dr is: In any given context, there should only ever be one and only one protocol implementation for a given class/protocol pair.

So far, these are the changes included in this PR:

1. Move `implements` into class bodies and allow more ergonomic implementation blocks that have property names automatically scoped to the protocol being implemented.
1. Add a new `implFor` keyword to `protocol` bodies that can be used to provide implementations for existing classes while guaranteeing there will only be one implementation for that protocol.
1. Remove the `Protocol` global, and thus `Protocol.implement`. Protocols can now only be implemented inside `class`, or inside `protocol`, and thus can only ever be implemented once, ever.
1. Remove the ability for protocols to define new minimal implementations for protocols they are extending. This feature would be a vector for multiple inheritance, and thus could potentially cause inheritance diamonds.
1. Protocols are no longer intended to worth through `Symbol` objects present in the protocol instance. Protocol properties are now accessed by getting the protocol implementation from the target object (as a property) to fetch the desired implementation abstraction object, which will have string properties corresponding to protocol properties. I still need to write more about the specifics of this, but tl;dr instead of `foo[MyProtocol.something]()`, you would do `foo[MyProtocol].something()` instead. This enables `super` and also allows static properties and methods on the prototype itself. I'm not entirely sure how the lookup semantics work right now, but this is the best solution I have so far.
1. The boolean `implements` keyword no longer checks if specific symbol properties are present to decide whether a protocol has been implemented. Instead, `x implements Foo` is `true` iff `x[Foo]` would successfully return an exotic implementation instance.
1. Protocols no longer support non-internal properties. That is, `prom.then()` must be defined by the class itself, not by the protocol. It is the responsibility of the class implementer to decide how to implement these public protocols.
1. The `static` keyword inside `protocol` declarations now add static properties/methods directly to the protocol instance itself, rather than the class a protocol is implemented on.
1. The `super` keyword has what would be the expected behavior, I think -- methods in parent implementations can be called with `super[MyProto].someMethod()`.

Thoughts? :)